### PR TITLE
fix: Correct register reading and conversion from 2 byte to 1

### DIFF
--- a/lis2ds12_reg.c
+++ b/lis2ds12_reg.c
@@ -119,9 +119,9 @@ float_t lis2ds12_from_fs16g_to_mg(int16_t lsb)
   return ((float_t)lsb * 0.488f);
 }
 
-float_t lis2ds12_from_lsb_to_celsius(int16_t lsb)
+float_t lis2ds12_from_lsb_to_celsius(int8_t lsb)
 {
-  return (((float_t)lsb / 256.0f) + 25.0f);
+  return (((float_t)lsb) + 25.0);
 }
 
 /**
@@ -510,19 +510,21 @@ int32_t lis2ds12_acceleration_module_raw_get(const stmdev_ctx_t *ctx,
 }
 
 /**
-  * @brief  Temperature data output register (r). L and H registers together
-  *         express a 16-bit word in two's complement.[get]
+  * @brief  Temperature data output register (r). The value is expressed
+  *         as two's complement sign. Sensitivity = 1 °C/LSB 0 LSB
+  *         represent T=25 °C ambient. (Use `lis2ds12_from_lsb_to_celsius`
+  *         to convert raw data)[get]
   *
   * @param  ctx    read / write interface definitions.(ptr)
   * @param  buff   buffer that stores data read.(ptr)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_temperature_raw_get(const stmdev_ctx_t *ctx, uint8_t *buff)
+int32_t lis2ds12_temperature_raw_get(const stmdev_ctx_t *ctx, int8_t *buff)
 {
   int32_t ret;
 
-  ret = lis2ds12_read_reg(ctx, LIS2DS12_OUT_T, buff, 1);
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_OUT_T, (uint8_t *)buff, 1);
 
   return ret;
 }

--- a/lis2ds12_reg.h
+++ b/lis2ds12_reg.h
@@ -920,7 +920,7 @@ float_t lis2ds12_from_fs4g_to_mg(int16_t lsb);
 float_t lis2ds12_from_fs8g_to_mg(int16_t lsb);
 float_t lis2ds12_from_fs16g_to_mg(int16_t lsb);
 
-float_t lis2ds12_from_lsb_to_celsius(int16_t lsb);
+float_t lis2ds12_from_lsb_to_celsius(int8_t lsb);
 
 typedef struct
 {
@@ -989,7 +989,7 @@ int32_t lis2ds12_acceleration_module_raw_get(const stmdev_ctx_t *ctx,
                                              uint8_t *buff);
 
 int32_t lis2ds12_temperature_raw_get(const stmdev_ctx_t *ctx,
-                                     uint8_t *buff);
+                                     int8_t *buff);
 
 int32_t lis2ds12_acceleration_raw_get(const stmdev_ctx_t *ctx,
                                       int16_t *val);


### PR DESCRIPTION
This PR solves #2: Temperature register is 1 byte long and represents 1 °C/LSB.
- Changed data type from uint8_t to int8_t in `temperature_raw_get` function.
- Fixed the conversion functions accordingly.